### PR TITLE
Changing to cookie based for redirection

### DIFF
--- a/Source/AzureContainerAppAuth.cs
+++ b/Source/AzureContainerAppAuth.cs
@@ -46,14 +46,4 @@ public static class AzureContainerAppAuth
 
         await Task.CompletedTask;
     }
-
-    public static void RedirectToOrigin(this HttpResponse response, HttpRequest request)
-    {
-        if (request.Headers.ContainsKey("x-original-uri") &&
-            request.Headers.ContainsKey("x-ai-original-host"))
-        {
-            var url = $"https://{request.Headers["x-ai-original-host"]}{request.Headers["x-original-uri"]}";
-            response.Redirect(url);
-        }
-    }
 }

--- a/Source/Config.cs
+++ b/Source/Config.cs
@@ -4,6 +4,7 @@ namespace Aksio.IngressMiddleware;
 
 public class Config
 {
+    public string CookieDomain { get; set; } = string.Empty;
     public OpenIDConnectConfig AzureAd { get; set; } = new OpenIDConnectConfig();
     public OpenIDConnectConfig IdPorten { get; set; } = new OpenIDConnectConfig();
     public TenantsConfig Tenants { get; set; } = new TenantsConfig();

--- a/Source/OpenIDConnectConfig.cs
+++ b/Source/OpenIDConnectConfig.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Aksio.IngressMiddleware;
 
 public class OpenIDConnectConfig

--- a/Source/Origin.cs
+++ b/Source/Origin.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.IngressMiddleware;
+
+public static class Origin
+{
+    const string OriginHeader = "x-ai-origin-uri";
+    const string OriginCookie = ".origin";
+
+    public static void Handle(Config config, HttpRequest request, HttpResponse response)
+    {
+        if (request.Headers.ContainsKey(OriginHeader))
+        {
+            if (request.Cookies.ContainsKey(OriginCookie))
+            {
+                return;
+            }
+
+            response.Cookies.Append(OriginCookie, request.Headers[OriginHeader], new() { Domain = config.CookieDomain });
+        }
+    }
+
+    public static void RedirectToOrigin(this HttpResponse response, HttpRequest request)
+    {
+        if (request.Cookies.ContainsKey(OriginCookie))
+        {
+            response.Redirect(request.Cookies[OriginCookie]!);
+        }
+    }
+}

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -19,6 +19,7 @@ Globals.Logger.LogInformation("Setting up routes");
 app.MapGet("/", async (HttpRequest request, HttpResponse response) =>
 {
     var config = configuration.Get<Config>();
+    Origin.Handle(config, request, response);
     await Cratis.HandleRequest(config, request, response);
     await AzureContainerAppAuth.HandleZumoHeader(config, request, response);
 });

--- a/Source/config/config.json
+++ b/Source/config/config.json
@@ -1,4 +1,5 @@
 {
+    "cookieDomain": ".localhost",
     "azureAd": {
         "issuer": "https://login.microsoftonline.com/1042fa82-e1c7-40a8-9c61-a7831ef3f10a/v2.0",
         "authorizationEndpoint": "https://login.microsoftonline.com/1042fa82-e1c7-40a8-9c61-a7831ef3f10a/oauth2/v2.0/authorize",


### PR DESCRIPTION
### Fixed

- Changing to cookies for holding which origin the first request is coming from. This is then used when we need to redirect after authentication.
