### PR TITLE
Fix cookie settings for origin cookie

### DIFF
--- a/Source/Origin.cs
+++ b/Source/Origin.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Web;
+
 namespace Aksio.IngressMiddleware;
 
 public static class Origin
@@ -32,7 +34,7 @@ public static class Origin
     {
         if (request.Cookies.ContainsKey(OriginCookie))
         {
-            response.Redirect(request.Cookies[OriginCookie]!);
+            response.Redirect(HttpUtility.UrlDecode(request.Cookies[OriginCookie]!));
         }
     }
 }

--- a/Source/Origin.cs
+++ b/Source/Origin.cs
@@ -19,7 +19,12 @@ public static class Origin
         if (request.Headers.ContainsKey(OriginHeader))
         {
             Globals.Logger.LogInformation("Origin header found - adding origin cookie");
-            response.Cookies.Append(OriginCookie, request.Headers[OriginHeader], new() { Domain = config.CookieDomain });
+            response.Cookies.Append(OriginCookie, request.Headers[OriginHeader], new()
+            {
+                Domain = config.CookieDomain,
+                Expires = DateTimeOffset.UtcNow.AddHours(1),
+                IsEssential = true
+            });
         }
     }
 


### PR DESCRIPTION
### Fixed

- Setting expires on origin cookie and making it an essential cookie.
- URL Decode the content of the origin cookie.
