### PR TITLE
Changing type for claims so the config builder can deserialize

### DIFF
--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+using System.Text.Json.Nodes;
 using Aksio.IngressMiddleware;
 using Serilog;
 

--- a/Source/TenantConfig.cs
+++ b/Source/TenantConfig.cs
@@ -7,5 +7,5 @@ public record TenantConfig
 {
     public string Domain { get; set; } = "localhost";
     public string OnBehalfOf { get; set; } = "";
-    public IEnumerable<string> TenantIdClaims { get; set; } = Enumerable.Empty<string>();
+    public string[] TenantIdClaims { get; set; } = new string[0];
 }


### PR DESCRIPTION
### Fixed

- Fixing config type for Tenant Id claims so that it gets deserialized.
