### PR TITLE
Make content of identity cookie be base64 encoded string

### DIFF
--- a/Sample/nginx.conf
+++ b/Sample/nginx.conf
@@ -51,6 +51,9 @@ http {
             auth_request_set $auth_resp_x_zumo_auth $upstream_http_x_zumo_auth;
             proxy_set_header X-ZUMO-AUTH $auth_resp_x_zumo_auth;
             add_header X-ZUMO-AUTH $auth_resp_x_zumo_auth;
+
+            auth_request_set $auth_resp_cookie $sent_http_set_cookie;
+            add_header Set-Cookie $auth_resp_cookie;
         }
 
         location /js {

--- a/Source/Identity.cs
+++ b/Source/Identity.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Net;
+using System.Text;
+
 namespace Aksio.IngressMiddleware;
 
 public static class Identity
@@ -23,8 +26,14 @@ public static class Identity
                 client.DefaultRequestHeaders.Add(Headers.PrincipalId, request.Headers[Headers.PrincipalId].ToString());
                 client.DefaultRequestHeaders.Add(Headers.PrincipalName, request.Headers[Headers.PrincipalName].ToString());
                 var responseMessage = await client.GetAsync(config.IdentityDetailsUrl);
+
+                if (responseMessage.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    response.StatusCode = 403;
+                }
                 var identityDetails = await responseMessage.Content.ReadAsStringAsync();
-                response.Cookies.Append(CookieName, identityDetails);
+                var identityDetailsAsBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(identityDetails));
+                response.Cookies.Append(CookieName, identityDetailsAsBase64);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Fixed

- Content of identity details are now a Base64 encoded string. This was an oversight.
- When identity provider returns 403, the entire middleware request will also return 403.

