### PR TITLE
Remove identity cookie to re-evaluate

### DIFF
--- a/Source/wwwroot/toolbarViewModel.js
+++ b/Source/wwwroot/toolbarViewModel.js
@@ -42,6 +42,7 @@ if (view) {
         document.cookie = `aksiodevprincipalid=${identity.id}`;
         document.cookie = `aksiodevprincipalname=${identity.name}`;
         document.cookie = `aksiodevprincipal=${btoa(JSON.stringify(identity))}`;
+        document.cookie = ".aksio-identity=;expires="+ new Date(0).toUTCString();
         location.reload();
     };
 


### PR DESCRIPTION
### Fixed

- The `.aksio-identity` cookie needs to be cleared in the toolbar when we change tenant or identity, since we need to re-evaluate and call the identity details endpoint on the application when that happens.
