### PR TITLE
Adding logging for no config and setting expiry of cookie to 5 minutes

### DIFF
--- a/Source/Identity.cs
+++ b/Source/Identity.cs
@@ -12,7 +12,11 @@ public static class Identity
 
     public static async Task HandleRequest(Config config, HttpRequest request, HttpResponse response, IHttpClientFactory httpClientFactory)
     {
-        if (string.IsNullOrEmpty(config.IdentityDetailsUrl)) return;
+        if (string.IsNullOrEmpty(config.IdentityDetailsUrl))
+        {
+            Globals.Logger.LogInformation("Identity details url is not configured, skipping identity details resolution");
+            return;
+        }
 
         if (!request.Cookies.ContainsKey(CookieName)
             && request.Headers.ContainsKey(Headers.Principal)
@@ -42,7 +46,7 @@ public static class Identity
                 }
 
                 var identityDetailsAsBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(identityDetails));
-                response.Cookies.Append(CookieName, identityDetailsAsBase64);
+                response.Cookies.Append(CookieName, identityDetailsAsBase64, new CookieOptions { Expires = DateTimeOffset.Now.AddMinutes(5) });
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Fixed

- Logging to see if identity details is not configured
- Temporary fixed timeout for identity cookie, till we fix #37 or expand on how to invalidate identity details.
