### PR TITLE
Taking out the WriteTo so that we easily override logging

### DIFF
--- a/Source/appsettings.json
+++ b/Source/appsettings.json
@@ -17,15 +17,6 @@
             "FromLogContext",
             "WithMachineName",
             "WithThreadId"
-        ],
-        "WriteTo": [
-            {
-                "Name": "Console",
-                "Args": {
-                    "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
-                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}"
-                }
-            }
         ]
     },
     "AllowedHosts": "*"


### PR DESCRIPTION
### Fixed

- Removing Serilog `WriteTo` for the base `appsettings.json`. This will allow to override this as Serilog combines sinks from all configuration sources.
