### PR TITLE
Fixing encoding for identity cookie

### DIFF
--- a/Source/Identity.cs
+++ b/Source/Identity.cs
@@ -56,9 +56,8 @@ public static class Identity
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 client.DefaultRequestHeaders.AcceptCharset.Add(new StringWithQualityHeaderValue("utf-8"));
                 client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("utf-8"));
-                
-                var responseMessage = await client.GetAsync(config.IdentityDetailsUrl);
 
+                var responseMessage = await client.GetAsync(config.IdentityDetailsUrl);
                 if (responseMessage.StatusCode == HttpStatusCode.Forbidden)
                 {
                     response.StatusCode = 403;

--- a/Source/Identity.cs
+++ b/Source/Identity.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using Aksio.Cratis.Execution;
 
@@ -52,6 +53,10 @@ public static class Identity
                 client.DefaultRequestHeaders.Add(Headers.PrincipalId, principalId);
                 client.DefaultRequestHeaders.Add(Headers.PrincipalName, principalName);
                 client.DefaultRequestHeaders.Add(Headers.TenantId, tenantId.ToString());
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.AcceptCharset.Add(new StringWithQualityHeaderValue("utf-8"));
+                client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("utf-8"));
+                
                 var responseMessage = await client.GetAsync(config.IdentityDetailsUrl);
 
                 if (responseMessage.StatusCode == HttpStatusCode.Forbidden)
@@ -66,7 +71,9 @@ public static class Identity
                     return;
                 }
 
-                var identityDetailsAsBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(identityDetails));
+                var encoding = Encoding.GetEncoding("iso-8859-1");
+                var encoded = encoding.GetBytes(identityDetails);
+                var identityDetailsAsBase64 = Convert.ToBase64String(encoded);
                 response.Cookies.Append(CookieName, identityDetailsAsBase64, new CookieOptions { Expires = DateTimeOffset.Now.AddMinutes(5) });
             }
             catch (Exception ex)


### PR DESCRIPTION
### Fixed

- Fixing encoding for identity details before Base64 encoding it into the target cookie. Browsers can with `atob()` convert ISO-8859-1 encoded strings, UTF-8 strings becomes scrambled when string contains special characters such as Norwegian Æ,Ø,Å.
