### PR TITLE
Fixing according to RFC7235 - 401 for invalid tokens- + adding messages

### DIFF
--- a/Source/AuthorityResult.cs
+++ b/Source/AuthorityResult.cs
@@ -3,4 +3,6 @@
 
 namespace Aksio.IngressMiddleware;
 
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+
 public record AuthorityResult(string issuer, string jwks_uri);

--- a/Source/OAuthBearerTokens.cs
+++ b/Source/OAuthBearerTokens.cs
@@ -8,7 +8,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Aksio.IngressMiddleware;
 
-public class OAuthBearerTokens
+public static class OAuthBearerTokens
 {
     static AuthorityResult? _authority;
     static JsonWebKeySet? _jwks;
@@ -46,10 +46,12 @@ public class OAuthBearerTokens
 
         if (_jwks is null || _authority is null) return;
 
-        var jwk = _jwks.Keys.First();
+        var jwk = _jwks.Keys[0];
         var validationParameters = new TokenValidationParameters
         {
             IssuerSigningKey = jwk,
+
+            #pragma warning disable CA5404 // Disable audience validation
             ValidateAudience = false,
             ValidIssuer = _authority.issuer
         };


### PR DESCRIPTION
### Added

- Adding support for OAuth bearer tokens authorization.
- Added `WWW-Authenticate` response headers with error messages and descriptions.

### Fixed

- All errored OAuth Bearer token scenarios now end up with a 401, which seems to be more correct according to RFC7235 (https://www.rfc-editor.org/rfc/rfc7235#section-3.1).
