### PR TITLE
Adding the missing 'None' for source identifier

### DIFF
--- a/Source/Tenancy/NoneSourceIdentifierResolver.cs
+++ b/Source/Tenancy/NoneSourceIdentifierResolver.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Cratis.Execution;
+using Aksio.IngressMiddleware.Configuration;
+
+namespace Aksio.IngressMiddleware.Tenancy;
+
+/// <summary>
+/// Represents an implementation of <see cref="ITenantResolver"/> that always resolves the tenant to NotSet.
+/// </summary>
+public class NoneSourceIdentifierResolver : ITenantSourceIdentifierResolver
+{
+    /// <inheritdoc/>
+    public Task<TenantId> Resolve(Config config, HttpRequest request) => Task.FromResult(TenantId.NotSet);
+}

--- a/Source/Tenancy/TenantSourceIdentifierResolvers.cs
+++ b/Source/Tenancy/TenantSourceIdentifierResolvers.cs
@@ -12,6 +12,7 @@ public static class TenantSourceIdentifierResolvers
 {
     static readonly Dictionary<TenantSourceIdentifierResolverType, ITenantSourceIdentifierResolver> _resolvers = new()
     {
+        { TenantSourceIdentifierResolverType.None, new NoneSourceIdentifierResolver() },
         { TenantSourceIdentifierResolverType.Claim, new ClaimsSourceIdentifierResolver() },
         { TenantSourceIdentifierResolverType.Route, new RouteSourceIdentifierResolver() }
     };


### PR DESCRIPTION
### Fixed

- Fixed so that you can ignore specifying the tenant resolver without it crashing. It will resolve to a default one which will always set `TenantId` to `NotSet`.
