### PR TITLE
Fix/not-impersonate-files

### DIFF
--- a/Source/Helpers/HttpRequestExtensions.cs
+++ b/Source/Helpers/HttpRequestExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Web;
+
 namespace Aksio.IngressMiddleware.Helpers;
 
 /// <summary>
@@ -14,6 +16,36 @@ public static class HttpRequestExtensions
     /// <param name="request"><see cref="HttpRequest"/> instance.</param>
     /// <returns>Original URI.</returns>
     public static Uri GetOriginalUri(this HttpRequest request) => new(request.Headers[Headers.OriginalUri].ToString());
+
+    /// <summary>
+    /// Gets the path from the original URI.
+    /// </summary>
+    /// <param name="request"><see cref="HttpRequest"/> instance.</param>
+    /// <returns>The path.</returns>
+    public static string GetPath(this HttpRequest request)
+    {
+        var path = request.GetOriginalUri().PathAndQuery;
+        path = HttpUtility.UrlDecode(path);
+        var queryIndex = path.IndexOf('?');
+        if (queryIndex > 0)
+        {
+            path = path.Substring(0, queryIndex);
+        }
+
+        return path;
+    }
+
+    /// <summary>
+    /// Gets whether or not the request has a file extension.
+    /// </summary>
+    /// <param name="request"><see cref="HttpRequest"/> instance.</param>
+    /// <returns>True if it does and false if not.</returns>
+    public static bool HasFileExtension(this HttpRequest request)
+    {
+        var path = request.GetPath();
+        var extension = Path.GetExtension(path);
+        return !string.IsNullOrEmpty(extension);
+    }
 
     /// <summary>
     /// Gets whether or not the request is an impersonation route.

--- a/Source/Impersonation/ImpersonationFlow.cs
+++ b/Source/Impersonation/ImpersonationFlow.cs
@@ -41,6 +41,11 @@ public class ImpersonationFlow : IImpersonationFlow
     /// <inheritdoc/>
     public bool ShouldImpersonate(HttpRequest request)
     {
+        if (request.HasFileExtension())
+        {
+            return false;
+        }
+
         if (!IsImpersonateRoute(request))
         {
             var principal = ClientPrincipal.FromBase64(request.Headers[Headers.PrincipalId], request.Headers[Headers.Principal]);

--- a/Source/RequestAugmenter.cs
+++ b/Source/RequestAugmenter.cs
@@ -51,7 +51,8 @@ public class RequestAugmenter : Controller
         var tenantId = await _tenantResolver.Resolve(Request);
         Response.Headers[Headers.TenantId] = tenantId.ToString();
 
-        if (!_impersonationFlow.HandleImpersonatedPrincipal(Request, Response) && _impersonationFlow.ShouldImpersonate(Request))
+        if (!_impersonationFlow.HandleImpersonatedPrincipal(Request, Response) &&
+            _impersonationFlow.ShouldImpersonate(Request))
         {
             Response.Headers[Headers.ImpersonationRedirect] = WellKnownPaths.Impersonation;
             return StatusCode(StatusCodes.Status401Unauthorized);

--- a/Specifications/Impersonation/for_ImpersonationFlow/when_asking_if_should_impersonate/and_route_is_not_impersonate_route_but_is_a_file.cs
+++ b/Specifications/Impersonation/for_ImpersonationFlow/when_asking_if_should_impersonate/and_route_is_not_impersonate_route_but_is_a_file.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Aksio.IngressMiddleware.Impersonation.when_asking_if_should_impersonate;
+
+public class and_route_is_not_impersonate_route_but_is_a_file : given.a_impersonation_flow
+{
+    DefaultHttpContext http_context;
+    bool result;
+
+    void Establish()
+    {
+        http_context = new();
+        http_context.Request.Headers[Headers.OriginalUri] = "/something/random/file.txt?query=string";
+    }
+
+    void Because() => result = flow.ShouldImpersonate(http_context.Request);
+
+    [Fact] void should_not_impersonate() => result.ShouldBeFalse();
+}


### PR DESCRIPTION
### Fixed

- During impersonation when forwarded to a UI that will present the impersonation options, that UI might be part of the application bundle containing the `/.aksio/impersonate` UI as a route. If this UI refers to assets its using on a different route, that should be allowed and these requests not considered as requests that needs to be impersonated. We're interested in the application data / context being impersonated, not the individual assets that make the application. This is now fixed in this release.
