### PR TITLE
Source identifiers are not tenant identifiers - reverting to working code

### DIFF
--- a/Source/Tenancy/ClaimsSourceIdentifierResolver.cs
+++ b/Source/Tenancy/ClaimsSourceIdentifierResolver.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using System.Text.Json.Nodes;
-using Aksio.Cratis.Execution;
 using Aksio.IngressMiddleware.Configuration;
 
 namespace Aksio.IngressMiddleware.Tenancy;
@@ -16,10 +15,8 @@ public class ClaimsSourceIdentifierResolver : TenantSourceIdentifierResolver, IT
     const string TenantIdClaim = "http://schemas.microsoft.com/identity/claims/tenantid";
 
     /// <inheritdoc/>
-    public Task<TenantId> Resolve(Config config, ClaimsSourceIdentifierResolverOptions options, HttpRequest request)
+    public Task<string> Resolve(Config config, ClaimsSourceIdentifierResolverOptions options, HttpRequest request)
     {
-        var sourceIdentifier = TenantId.NotSet;
-
         if (request.Headers.ContainsKey(Headers.Principal))
         {
             var token = Convert.FromBase64String(request.Headers[Headers.Principal]);
@@ -31,11 +28,11 @@ public class ClaimsSourceIdentifierResolver : TenantSourceIdentifierResolver, IT
                 var tenantObject = claimsAsArray.Cast<JsonObject>().FirstOrDefault(_ => _.TryGetPropertyValue("typ", out var type) && type!.ToString() == TenantIdClaim);
                 if (tenantObject is not null && tenantObject.TryGetPropertyValue("val", out var tenantValue) && tenantValue is not null)
                 {
-                    return Task.FromResult(new TenantId(Guid.Parse(tenantValue.ToString())));
+                    return Task.FromResult(tenantValue.ToString());
                 }
             }
         }
 
-        return Task.FromResult(sourceIdentifier);
+        return Task.FromResult(string.Empty);
     }
 }

--- a/Source/Tenancy/ITenantSourceIdentifierResolver.cs
+++ b/Source/Tenancy/ITenantSourceIdentifierResolver.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Aksio.Cratis.Execution;
 using Aksio.IngressMiddleware.Configuration;
 
 namespace Aksio.IngressMiddleware.Tenancy;
@@ -16,8 +15,8 @@ public interface ITenantSourceIdentifierResolver
     /// </summary>
     /// <param name="config"><see cref="Config"/> instance.</param>
     /// <param name="request"><see cref="HttpRequest"/> to resolve from.</param>
-    /// <returns>Resolved <see cref="TenantId"/>.</returns>
-    Task<TenantId> Resolve(Config config, HttpRequest request);
+    /// <returns>Resolved source identifier.</returns>
+    Task<string> Resolve(Config config, HttpRequest request);
 }
 
 /// <summary>
@@ -32,6 +31,6 @@ public interface ITenantSourceIdentifierResolver<TOptions> : ITenantSourceIdenti
     /// <param name="config"><see cref="Config"/> instance.</param>
     /// <param name="options">The options associated with the resolver.</param>
     /// <param name="request"><see cref="HttpRequest"/> to resolve from.</param>
-    /// <returns>Resolved <see cref="TenantId"/>.</returns>
-    Task<TenantId> Resolve(Config config, TOptions options, HttpRequest request);
+    /// <returns>Resolved source identifier.</returns>
+    Task<string> Resolve(Config config, TOptions options, HttpRequest request);
 }

--- a/Source/Tenancy/NoneSourceIdentifierResolver.cs
+++ b/Source/Tenancy/NoneSourceIdentifierResolver.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Aksio.Cratis.Execution;
 using Aksio.IngressMiddleware.Configuration;
 
 namespace Aksio.IngressMiddleware.Tenancy;
@@ -12,5 +11,5 @@ namespace Aksio.IngressMiddleware.Tenancy;
 public class NoneSourceIdentifierResolver : ITenantSourceIdentifierResolver
 {
     /// <inheritdoc/>
-    public Task<TenantId> Resolve(Config config, HttpRequest request) => Task.FromResult(TenantId.NotSet);
+    public Task<string> Resolve(Config config, HttpRequest request) => Task.FromResult(string.Empty);
 }

--- a/Source/Tenancy/RouteSourceIdentifierResolver.cs
+++ b/Source/Tenancy/RouteSourceIdentifierResolver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.RegularExpressions;
-using Aksio.Cratis.Execution;
 using Aksio.IngressMiddleware.Configuration;
 
 namespace Aksio.IngressMiddleware.Tenancy;
@@ -19,7 +18,7 @@ public class RouteSourceIdentifierResolver : TenantSourceIdentifierResolver, ITe
     readonly IDictionary<string, Regex> _regularExpressions = new Dictionary<string, Regex>();
 
     /// <inheritdoc/>
-    public Task<TenantId> Resolve(Config config, RouteSourceIdentifierResolverOptions options, HttpRequest request)
+    public Task<string> Resolve(Config config, RouteSourceIdentifierResolverOptions options, HttpRequest request)
     {
         var originalUri = request.Headers[Headers.OriginalUri].FirstOrDefault() ?? string.Empty;
 
@@ -35,10 +34,10 @@ public class RouteSourceIdentifierResolver : TenantSourceIdentifierResolver, ITe
             var value = match.Groups[SourceIdentifier].Value;
             if (!string.IsNullOrEmpty(value))
             {
-                return Task.FromResult(new TenantId(Guid.Parse(value)));
+                return Task.FromResult(value);
             }
         }
 
-        return Task.FromResult(TenantId.NotSet);
+        return Task.FromResult(string.Empty);
     }
 }

--- a/Source/Tenancy/TenantResolver.cs
+++ b/Source/Tenancy/TenantResolver.cs
@@ -37,7 +37,7 @@ public class TenantResolver : ITenantResolver
         var tenantId = string.Empty;
         var sourceIdentifier = await _resolver.Resolve(_config, request);
 
-        if (sourceIdentifier != TenantId.NotSet)
+        if (!string.IsNullOrEmpty(tenantId))
         {
             var tenant = _config.Tenants.FirstOrDefault(_ => _.Value.SourceIdentifiers.Any(t => t == sourceIdentifier));
             tenantId = tenant.Key;

--- a/Source/Tenancy/TenantSourceIdentifierResolver.cs
+++ b/Source/Tenancy/TenantSourceIdentifierResolver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
-using Aksio.Cratis.Execution;
 using Aksio.IngressMiddleware.Configuration;
 
 namespace Aksio.IngressMiddleware.Tenancy;
@@ -13,7 +12,7 @@ namespace Aksio.IngressMiddleware.Tenancy;
 public class TenantSourceIdentifierResolver : ITenantSourceIdentifierResolver
 {
     /// <inheritdoc/>
-    public async Task<TenantId> Resolve(Config config, HttpRequest request)
+    public async Task<string> Resolve(Config config, HttpRequest request)
     {
         var genericResolverInterface = GetType().GetInterface(typeof(ITenantSourceIdentifierResolver<>).Name);
         if (genericResolverInterface is not null)
@@ -23,9 +22,9 @@ public class TenantSourceIdentifierResolver : ITenantSourceIdentifierResolver
             {
                 var targetOptionsTypes = genericResolverInterface.GetGenericArguments()[0];
                 var options = config.TenantResolution.Options.Deserialize(targetOptionsTypes, Globals.JsonSerializerOptions)!;
-                return await (method.Invoke(this, new object[] { config, options, request }) as Task<TenantId>)!;
+                return await (method.Invoke(this, new object[] { config, options, request }) as Task<string>)!;
             }
         }
-        return TenantId.NotSet;
+        return string.Empty;
     }
 }


### PR DESCRIPTION
### Fixed

- Fixing `ITenantSourceIdentifierResolver` and implementations to return string, this is their purpose - to resolve to a source identifier that will then be used to map back to the real tenant identifier.
