### PR TITLE
Fix/set-identity-cookie-on-impersonation

### DIFF
--- a/Specifications/Impersonation/for_Impersonator/when_authorizing_impersonation/given/an_impersonator.cs
+++ b/Specifications/Impersonation/for_Impersonator/when_authorizing_impersonation/given/an_impersonator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Aksio.IngressMiddleware.Identities;
+using Aksio.IngressMiddleware.Tenancy;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -12,14 +14,18 @@ public class an_impersonator : Specification
     protected Impersonator impersonator;
     protected Mock<IServiceProvider> service_provider;
     protected Mock<IImpersonationAuthorizer> authorizer;
+    protected Mock<ITenantResolver> tenant_resolver;
+    protected Mock<IIdentityDetailsResolver> identity_details_resolver;
 
     void Establish()
     {
         service_provider = new Mock<IServiceProvider>();
         authorizer = new();
+        tenant_resolver = new();
+        identity_details_resolver = new();
         service_provider.Setup(_ => _.GetService(IsAny<Type>())).Returns(authorizer.Object);
 
-        impersonator = new(service_provider.Object, Mock.Of<ILogger<Impersonator>>())
+        impersonator = new(service_provider.Object, identity_details_resolver.Object, tenant_resolver.Object,  Mock.Of<ILogger<Impersonator>>())
         {
             ControllerContext = new ControllerContext
             {


### PR DESCRIPTION
### Fixed

- Fixed so that we return the identity cookie when doing an impersonation by leveraging the identity details directly. If for some reason the identity details endpoint (**.aksio/me**) returns anything but HTTP 200, we'll delete the identity cookie and return a forbidden.
