### PR TITLE
Set principal before calling identity resolver

### DIFF
--- a/Source/Identities/IIdentityDetailsResolver.cs
+++ b/Source/Identities/IIdentityDetailsResolver.cs
@@ -16,7 +16,16 @@ public interface IIdentityDetailsResolver
     /// <param name="request"><see cref="HttpRequest"/> to resolve from.</param>
     /// <param name="response"><see cref="HttpResponse"/> to provide feedback on.</param>
     /// <param name="tenantId"><see cref="TenantId"/> to resolve for.</param>
-    /// <param name="isImpersonated">Whether or not this is impersonation, which means we ignore current identity. Defaults to false.</param>
     /// <returns>True if could resolve, false if not.</returns>
-    Task<bool> Resolve(HttpRequest request, HttpResponse response, TenantId tenantId, bool isImpersonated = false);
+    Task<bool> Resolve(HttpRequest request, HttpResponse response, TenantId tenantId);
+
+    /// <summary>
+    /// Resolve the details of an identity.
+    /// </summary>
+    /// <param name="request"><see cref="HttpRequest"/> to resolve from.</param>
+    /// <param name="response"><see cref="HttpResponse"/> to provide feedback on.</param>
+    /// <param name="principal">Base64 representation of the Microsoft client principal.</param>
+    /// <param name="tenantId"><see cref="TenantId"/> to resolve for.</param>
+    /// <returns>True if could resolve, false if not.</returns>
+    Task<bool> Resolve(HttpRequest request, HttpResponse response, string principal, TenantId tenantId);
 }

--- a/Source/Impersonation/Impersonator.cs
+++ b/Source/Impersonation/Impersonator.cs
@@ -73,10 +73,9 @@ public class Impersonator : Controller
         var newPrincipalAsBase64 = newPrincipal.ToBase64();
         Response.Headers[Headers.Principal] = newPrincipalAsBase64;
         Response.Cookies.Append(Cookies.Impersonation, newPrincipalAsBase64, new CookieOptions { Expires = null! });
-        Request.Headers[Headers.Principal] = newPrincipalAsBase64;
 
         var tenantId = await _tenantResolver.Resolve(Request);
-        if (!await _identityDetailsResolver.Resolve(Request, Response, tenantId, true))
+        if (!await _identityDetailsResolver.Resolve(Request, Response, newPrincipalAsBase64, tenantId))
         {
             Response.Cookies.Delete(Cookies.Identity);
             return StatusCode(StatusCodes.Status403Forbidden);

--- a/Source/Impersonation/Impersonator.cs
+++ b/Source/Impersonation/Impersonator.cs
@@ -73,6 +73,7 @@ public class Impersonator : Controller
         var newPrincipalAsBase64 = newPrincipal.ToBase64();
         Response.Headers[Headers.Principal] = newPrincipalAsBase64;
         Response.Cookies.Append(Cookies.Impersonation, newPrincipalAsBase64, new CookieOptions { Expires = null! });
+        Request.Headers[Headers.Principal] = newPrincipalAsBase64;
 
         var tenantId = await _tenantResolver.Resolve(Request);
         if (!await _identityDetailsResolver.Resolve(Request, Response, tenantId, true))

--- a/Source/Tenancy/TenantResolver.cs
+++ b/Source/Tenancy/TenantResolver.cs
@@ -50,7 +50,7 @@ public class TenantResolver : ITenantResolver
 
         if (string.IsNullOrEmpty(tenantId))
         {
-            _logger.LogInformation("Attempting to resolve tenant using host.");
+            _logger.LogInformation("Attempting to resolve tenant using host '{Host}'.", request.Host.Host);
             var tenant = _config.Tenants.FirstOrDefault(_ => _.Value.Domain.Equals(request.Host.Host));
             tenantId = tenant.Key;
             if (!string.IsNullOrEmpty(tenantId))

--- a/Source/Tenancy/TenantResolver.cs
+++ b/Source/Tenancy/TenantResolver.cs
@@ -39,6 +39,7 @@ public class TenantResolver : ITenantResolver
 
         if (!string.IsNullOrEmpty(sourceIdentifier))
         {
+            _logger.LogInformation("Attempting to resolve tenant using source identifier.");
             var tenant = _config.Tenants.FirstOrDefault(_ => _.Value.SourceIdentifiers.Any(t => t == sourceIdentifier));
             tenantId = tenant.Key;
             if (!string.IsNullOrEmpty(tenantId))
@@ -49,6 +50,7 @@ public class TenantResolver : ITenantResolver
 
         if (string.IsNullOrEmpty(tenantId))
         {
+            _logger.LogInformation("Attempting to resolve tenant using host.");
             var tenant = _config.Tenants.FirstOrDefault(_ => _.Value.Domain.Equals(request.Host.Host));
             tenantId = tenant.Key;
             if (!string.IsNullOrEmpty(tenantId))

--- a/Specifications/for_RequestAugmenter/when_handling_impersonated_route.cs
+++ b/Specifications/for_RequestAugmenter/when_handling_impersonated_route.cs
@@ -13,7 +13,7 @@ public class when_handling_impersonated_route : given.a_request_augmenter
 
     void Establish()
     {
-        identity_details_resolver.Setup(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id, false)).ReturnsAsync(true);
+        identity_details_resolver.Setup(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id)).ReturnsAsync(true);
         bearer_tokens.Setup(_ => _.Handle(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id)).ReturnsAsync(new OkResult());
         cookie_value = Guid.NewGuid().ToString();
 
@@ -24,6 +24,6 @@ public class when_handling_impersonated_route : given.a_request_augmenter
 
     [Fact] void should_ask_impersonation_flow_to_handle_impersonated_principal() => impersonation_flow.Verify(_ => _.HandleImpersonatedPrincipal(IsAny<HttpRequest>(), IsAny<HttpResponse>()), Once);
     [Fact] void should_return_ok() => result.ShouldBeOfExactType<OkResult>();
-    [Fact] void should_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id, false), Once);
+    [Fact] void should_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id), Once);
     [Fact] void should_handle_bearer_tokens() => bearer_tokens.Verify(_ => _.Handle(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id), Once);
 }

--- a/Specifications/for_RequestAugmenter/when_handling_impersonation_route.cs
+++ b/Specifications/for_RequestAugmenter/when_handling_impersonation_route.cs
@@ -14,6 +14,6 @@ public class when_handling_impersonation_route : given.a_request_augmenter
     async Task Because() => result = await augmenter.Get();
 
     [Fact] void should_return_ok() => result.ShouldBeOfExactType<OkResult>();
-    [Fact] void should_not_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(request, response, tenant_id, false), Never);
+    [Fact] void should_not_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(request, response, tenant_id), Never);
     [Fact] void should_not_handle_bearer_tokens() => bearer_tokens.Verify(_ => _.Handle(request, response, tenant_id), Never);
 }

--- a/Specifications/for_RequestAugmenter/when_handling_non_impersonated_route_and_identity_provider_requires_impersonation.cs
+++ b/Specifications/for_RequestAugmenter/when_handling_non_impersonated_route_and_identity_provider_requires_impersonation.cs
@@ -16,6 +16,6 @@ public class when_handling_non_impersonated_route_and_identity_provider_requires
 
     [Fact] void should_set_redirect_header() => response.Headers[Headers.ImpersonationRedirect].ShouldEqual(WellKnownPaths.Impersonation);
     [Fact] void should_return_forbidden() => ((StatusCodeResult)result).StatusCode.ShouldEqual(StatusCodes.Status401Unauthorized);
-    [Fact] void should_not_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(request, response, tenant_id, false), Never);
+    [Fact] void should_not_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(request, response, tenant_id), Never);
     [Fact] void should_not_handle_bearer_tokens() => bearer_tokens.Verify(_ => _.Handle(request, response, tenant_id), Never);
 }

--- a/Specifications/for_RequestAugmenter/when_handling_regular_route_and_all_is_valid.cs
+++ b/Specifications/for_RequestAugmenter/when_handling_regular_route_and_all_is_valid.cs
@@ -12,13 +12,13 @@ public class when_handling_regular_route_and_all_is_valid : given.a_request_augm
 
     void Establish()
     {
-        identity_details_resolver.Setup(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id, false)).ReturnsAsync(true);
+        identity_details_resolver.Setup(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id)).ReturnsAsync(true);
         bearer_tokens.Setup(_ => _.Handle(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id)).ReturnsAsync(new OkResult());
     }
 
     async Task Because() => result = await augmenter.Get();
 
     [Fact] void should_return_ok() => result.ShouldBeOfExactType<OkResult>();
-    [Fact] void should_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id, false), Once);
+    [Fact] void should_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id), Once);
     [Fact] void should_handle_bearer_tokens() => bearer_tokens.Verify(_ => _.Handle(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id), Once);
 }

--- a/Specifications/for_RequestAugmenter/when_handling_regular_route_and_bearer_token_is_not_authorized.cs
+++ b/Specifications/for_RequestAugmenter/when_handling_regular_route_and_bearer_token_is_not_authorized.cs
@@ -13,7 +13,7 @@ public class when_handling_regular_route_and_bearer_token_is_not_authorized : gi
 
     void Establish()
     {
-        identity_details_resolver.Setup(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id, false)).ReturnsAsync(true);
+        identity_details_resolver.Setup(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id)).ReturnsAsync(true);
 
         bearer_token_result = new StatusCodeResult(StatusCodes.Status401Unauthorized);
         bearer_tokens.Setup(_ => _.Handle(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id)).ReturnsAsync(bearer_token_result);
@@ -22,5 +22,5 @@ public class when_handling_regular_route_and_bearer_token_is_not_authorized : gi
     async Task Because() => result = await augmenter.Get();
 
     [Fact] void should_return_result_from_bearer_tokens() => result.ShouldEqual(bearer_token_result);
-    [Fact] void should_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id, false), Once);
+    [Fact] void should_resolve_identity_details() => identity_details_resolver.Verify(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id), Once);
 }

--- a/Specifications/for_RequestAugmenter/when_handling_regular_route_that_fails_identity_resolution.cs
+++ b/Specifications/for_RequestAugmenter/when_handling_regular_route_that_fails_identity_resolution.cs
@@ -12,7 +12,7 @@ public class when_handling_regular_route_that_fails_identity_resolution : given.
 
     void Establish()
     {
-        identity_details_resolver.Setup(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id, false)).ReturnsAsync(false);
+        identity_details_resolver.Setup(_ => _.Resolve(IsAny<HttpRequest>(), IsAny<HttpResponse>(), tenant_id)).ReturnsAsync(false);
     }
 
     async Task Because() => result = await augmenter.Get();


### PR DESCRIPTION
### Fixed

- Setting the `x-ms-client-principal` header to the new impersonated principal before calling the `IdentityResolver` - that way it uses the correct principal when calling the application.
